### PR TITLE
attach workspace in case of build failure

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,6 +41,8 @@ jobs:
         default: "amd64"
     steps:
       - checkout
+      - attach_workspace:
+          at: /tmp/workspace
       - run:
           name: Build forwarder
           command: |


### PR DESCRIPTION
## Summary
Attach workspace to allow handling jira ticket in case of a build & publish failure.
