### PR TITLE
Return empty tags if none were found

### DIFF
--- a/enrich/enricher_test.go
+++ b/enrich/enricher_test.go
@@ -1,0 +1,91 @@
+package enrich
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/edgedelta/edgedelta-forwarder/cfg"
+	"github.com/edgedelta/edgedelta-forwarder/resource"
+	"github.com/google/go-cmp/cmp"
+)
+
+type mockResourceClient struct {
+	tags map[string]map[string]string
+	err  error
+}
+
+func (m *mockResourceClient) GetResourceTags(ctx context.Context, resourceARNs ...string) (map[string]map[string]string, error) {
+	return m.tags, m.err
+}
+
+func TestGetLambdaTags(t *testing.T) {
+	functionARN := "function:1"
+
+	tests := []struct {
+		desc           string
+		config         *cfg.Config
+		resourceClient resource.Client
+		wantTags       map[string]string
+	}{
+		{
+			desc: "got tags from resources",
+			config: &cfg.Config{
+				ForwardLambdaTags:    true,
+				ForwardForwarderTags: true,
+				Region:               "us-west-2",
+			},
+			resourceClient: &mockResourceClient{
+				tags: map[string]map[string]string{
+					functionARN: {
+						"tag1": "val1",
+					},
+				},
+			},
+			wantTags: map[string]string{
+				"tag1": "val1",
+			},
+		},
+		{
+			desc: "error while getting tags from resources",
+			config: &cfg.Config{
+				ForwardLambdaTags:    true,
+				ForwardForwarderTags: true,
+				Region:               "us-west-2",
+			},
+			resourceClient: &mockResourceClient{
+				tags: nil,
+				err:  errors.New("no tags for this function"),
+			},
+			wantTags: map[string]string{},
+		},
+		{
+			desc: "got empty tags from resources",
+			config: &cfg.Config{
+				ForwardLambdaTags:    true,
+				ForwardForwarderTags: true,
+				Region:               "us-west-2",
+			},
+			resourceClient: &mockResourceClient{
+				tags: map[string]map[string]string{},
+				err:  nil,
+			},
+			wantTags: map[string]string{},
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.desc, func(t *testing.T) {
+			// Clear global cache
+			defer delete(resourceARNToTagsCache, functionARN)
+
+			enricher := NewEnricher(tc.config, tc.resourceClient)
+			gotTags := enricher.getLambdaTags(context.TODO(), functionARN)
+			if diff := cmp.Diff(tc.wantTags, gotTags); diff != "" {
+				t.Errorf("Tags mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+
+}

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/config v1.18.41
 	github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi v1.16.0
 	github.com/cenkalti/backoff v2.2.1+incompatible
+	github.com/google/go-cmp v0.5.8
 )
 
 require (

--- a/resource/client.go
+++ b/resource/client.go
@@ -9,11 +9,15 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi"
 )
 
+type Client interface {
+	GetResourceTags(ctx context.Context, resourceARNs ...string) (map[string]map[string]string, error)
+}
+
 type DefaultClient struct {
 	svc *resourcegroupstaggingapi.Client
 }
 
-func NewAWSClient() (*DefaultClient, error) {
+func NewAWSClient() (Client, error) {
 	cfg, err := config.LoadDefaultConfig(context.TODO())
 	if err != nil {
 		return nil, fmt.Errorf("failed to load AWS SDK config, err: %v", err)


### PR DESCRIPTION
## Summary

The image shows an error for assigning a value to a nil map 
![image](https://github.com/edgedelta/edgedelta-forwarder/assets/3440089/348c395a-42e3-46f0-ab1c-9aab17374dd1)

The issue seems to be that `getLambdaTags` returns a nil `tags` in 
```
if forwarderARN != "" && e.forwardForwarderTags {
  tags = e.getLambdaTags(ctx, forwarderARN)
}
```
Later on in 
```
if foundLambdaLogGroup && e.forwardLambdaTags {
  t := e.getLambdaTags(ctx, functionARN)
  for k, v := range t {
    tags[k] = v
  }
}
```
The assignment happens.  

The logic is changed to return an empty map for tags when there is an error getting the data from resources client, or when the map of tags returned is empty.  
Created an interface for resources client to facilitate testing. 

## Testing

- Added test cases for lambda tags retrieval.