### PR TITLE
add ability to prefixing source tags to prevent duplication

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ AWS lambda function to forward logs from AWS to Edge Delta agent.
 - ED_FORWARD_LOG_GROUP_TAGS: If set to true, log group tags are fetched. Requires "tag:GetResources" permission.
 - ED_PUSH_TIMEOUT_SEC: Push timeout is the total duration of waiting for to send one batch of logs (in seconds). Default is 10.
 - ED_RETRY_INTERVAL_MS: RetryInterval is the initial interval to wait until next retry (in milliseconds). It is increased exponentially until our process is shut down. Default is 100.
+- ED_SOURCE_TAG_PREFIXES: Comma separated list of tag prefixes to be added to the source tags. For example, if ED_SOURCE_TAG_PREFIXES has "ed_forwarder=ed_fwd_", then all the forwarder tags will be prefixed with "ed_fwd_". Default is empty. Refer to mapping below for the list of tags keys.
 
 
 ## Manual Build
@@ -104,4 +105,22 @@ Forwarder lambda function sends logs in the following format:
         ...
     ]
 }
+```
+
+## Source Tags Prefix Mapping
+- Edge Delta Forwarder: ed_forwarder
+- Cloudwatch Log Group: log_group
+- Lambda: lambda
+- Sagemaker: sagemaker
+- ECS Task: ecs_task
+- ECS Cluster: ecs_cluster
+- ECS Service: ecs_service
+- EC2: ec2
+- SNS: sns
+... 
+The rest of the tag prefix keys are the same with the Amazon service name. For example, if the source is EKS, then the tag prefix key is eks. Thus, to prefix EKS tags ED_SOURCE_TAG_PREFIXES should have "eks=eks_prefix_".
+
+Example:
+```
+ED_SOURCE_TAG_PREFIXES=ed_forwarder=ed_fwd_,lambda=lambda_prefix_,sagemaker=sagemaker_prefix_
 ```

--- a/cfg/config.go
+++ b/cfg/config.go
@@ -11,13 +11,14 @@ import (
 
 // Config for storing all parameters
 type Config struct {
-	Region               string
-	EDEndpoint           string
-	PushTimeout          time.Duration
-	RetryInterval        time.Duration
-	ForwardForwarderTags bool
-	ForwardSourceTags    bool
-	ForwardLogGroupTags  bool
+	Region                    string
+	EDEndpoint                string
+	PushTimeout               time.Duration
+	RetryInterval             time.Duration
+	ForwardForwarderTags      bool
+	ForwardSourceTags         bool
+	ForwardLogGroupTags       bool
+	SourceEnvironmentPrefixes string
 }
 
 func GetConfig() (*Config, error) {
@@ -63,6 +64,8 @@ func GetConfig() (*Config, error) {
 	} else {
 		config.RetryInterval = 100 * time.Millisecond
 	}
+
+	config.SourceEnvironmentPrefixes = os.Getenv("ED_SOURCE_TAG_PREFIXES")
 
 	config.ForwardForwarderTags = os.Getenv("ED_FORWARD_FORWARDER_TAGS") == "true"
 	config.ForwardSourceTags = os.Getenv("ED_FORWARD_SOURCE_TAGS") == "true"

--- a/enrich/enricher.go
+++ b/enrich/enricher.go
@@ -228,9 +228,11 @@ func prepareSourcePrefixMap(prefixes string) map[tag.Source]string {
 	prefixMap := make(map[tag.Source]string)
 	parts := strings.Split(prefixes, ",")
 	for _, p := range parts {
-		parts := strings.Split(p, "=")
+		parts := strings.Split(strings.TrimSpace(p), "=")
 		if len(parts) == 2 {
-			prefixMap[tag.Source(parts[0])] = parts[1]
+			key := tag.Source(strings.TrimSpace(parts[0]))
+			value := strings.TrimSpace(parts[1])
+			prefixMap[key] = value
 		}
 	}
 

--- a/enrich/enricher_test.go
+++ b/enrich/enricher_test.go
@@ -2,13 +2,78 @@ package enrich
 
 import (
 	"context"
-	"errors"
 	"testing"
 
 	"github.com/edgedelta/edgedelta-forwarder/cfg"
 	"github.com/edgedelta/edgedelta-forwarder/lambda"
 	"github.com/edgedelta/edgedelta-forwarder/resource"
+	"github.com/edgedelta/edgedelta-forwarder/tag"
+	"github.com/edgedelta/edgedelta-forwarder/utils"
 	"github.com/google/go-cmp/cmp"
+)
+
+const (
+	functionARN   = "arn:aws:lambda:us-west-2:123456789012:function:my-function"
+	forwarderARN  = "arn:aws:lambda:us-west-2:123456789012:function:forwarder"
+	logGroupARN   = "arn:aws:logs:us-west-2:123456789012:log-group:my-log-group"
+	ecsTaskARN    = "arn:aws:ecs:us-west-2:123456789012:task/my-cluster/1234567890123456789"
+	ecsClusterARN = "arn:aws:ecs:us-west-2:123456789012:cluster/my-cluster"
+	ecsServiceARN = "arn:aws:ecs:us-west-2:123456789012:service/my-cluster/my-service"
+)
+
+func copyMap(m map[string]string) map[string]string {
+	var newMap = make(map[string]string)
+	for k, v := range m {
+		newMap[k] = v
+	}
+	return newMap
+}
+
+var (
+	logGroupTags = map[string]string{
+		"customer_log_group_tag":   "test_1",
+		"customer_log_group_tag_2": "log_group_tag_2",
+	}
+
+	functionTags = map[string]string{
+		"customer_lambda_tag":   "test_1",
+		"customer_lambda_tag_2": "lambda_tag_2",
+		"environment":           "dev",
+	}
+	forwarderTags = map[string]string{
+		"customer_forwarder_tag":   "test_1",
+		"customer_forwarder_tag_2": "forwarder_tag_2",
+		"environment":              "dev",
+	}
+
+	ecsTaskTags = map[string]string{
+		"customer_ecs_task_tag":   "test_1",
+		"customer_ecs_task_tag_2": "ecs_task_tag_2",
+		"environment":             "dev",
+	}
+
+	ecsClusterTags = map[string]string{
+		"customer_ecs_cluster_tag":   "test_1",
+		"customer_ecs_cluster_tag_2": "ecs_cluster_tag_2",
+		"environment":                "dev",
+	}
+
+	ecsServiceTags = map[string]string{
+		"customer_ecs_service_tag":   "test_1",
+		"customer_ecs_service_tag_2": "ecs_service_tag_2",
+		"environment":                "dev",
+	}
+)
+
+var (
+	arnToSourceMap = map[string]tag.Source{
+		functionARN:   "lambda",
+		logGroupARN:   tag.SourceLogGroup,
+		forwarderARN:  tag.SourceForwarder,
+		ecsClusterARN: tag.SourceECSCluster,
+		ecsTaskARN:    tag.SourceECSTask,
+		ecsServiceARN: tag.SourceECSService,
+	}
 )
 
 type mockResourceClient struct {
@@ -21,72 +86,205 @@ func (m *mockResourceClient) GetResourceTags(ctx context.Context, resourceARNs .
 }
 
 func TestGetLambdaTags(t *testing.T) {
-	functionARN := "function:1"
-	forwarderARN := "function:2"
-	logGroupARN := "logGroup:1"
+	type testCase struct {
+		desc             string
+		config           *cfg.Config
+		isSourceLambda   bool
+		resourceClient   resource.Client
+		arnsToGetTags    []string
+		wantFaasTags     map[string]string
+		wantSourceTags   map[string]string
+		wantLogGroupTags map[string]string
+	}
 
-	tests := []struct {
-		desc           string
-		config         *cfg.Config
-		resourceClient resource.Client
-		wantFaasTags   map[string]string
-	}{
-		{
-			desc: "got tags from resources",
-			config: &cfg.Config{
-				ForwardSourceTags:    true,
-				ForwardForwarderTags: true,
-				Region:               "us-west-2",
-			},
-			resourceClient: &mockResourceClient{
-				tags: map[string]map[string]string{
-					functionARN: {
-						"tag1": "val1",
+	tests := []func() testCase{
+		func() testCase {
+			return testCase{
+
+				desc: "Get tags when source is lambda and without forwarder tags",
+				config: &cfg.Config{
+					ForwardSourceTags:         true,
+					ForwardForwarderTags:      false,
+					ForwardLogGroupTags:       true,
+					Region:                    "us-west-2",
+					SourceEnvironmentPrefixes: "",
+				},
+				resourceClient: &mockResourceClient{
+					tags: map[string]map[string]string{
+						functionARN:  copyMap(functionTags),
+						logGroupARN:  copyMap(logGroupTags),
+						forwarderARN: copyMap(forwarderTags),
 					},
 				},
-			},
-			wantFaasTags: map[string]string{
-				"tag1": "val1",
-			},
+				arnsToGetTags:    []string{functionARN, logGroupARN},
+				isSourceLambda:   true,
+				wantSourceTags:   nil,
+				wantLogGroupTags: copyMap(logGroupTags),
+				wantFaasTags:     copyMap(functionTags),
+			}
 		},
-		{
-			desc: "error while getting tags from resources",
-			config: &cfg.Config{
-				ForwardSourceTags:    true,
-				ForwardForwarderTags: true,
-				Region:               "us-west-2",
-			},
-			resourceClient: &mockResourceClient{
-				tags: nil,
-				err:  errors.New("no tags for this function"),
-			},
-			wantFaasTags: map[string]string{},
+		func() testCase {
+			return testCase{
+				desc: "Get tags when source is lambda and with forwarder tags",
+				config: &cfg.Config{
+					ForwardSourceTags:         true,
+					ForwardForwarderTags:      true,
+					ForwardLogGroupTags:       true,
+					Region:                    "us-west-2",
+					SourceEnvironmentPrefixes: "",
+				},
+				arnsToGetTags:  []string{functionARN, logGroupARN, forwarderARN},
+				isSourceLambda: true,
+				resourceClient: &mockResourceClient{
+					tags: map[string]map[string]string{
+						functionARN:  copyMap(functionTags),
+						logGroupARN:  copyMap(logGroupTags),
+						forwarderARN: copyMap(forwarderTags),
+					},
+				},
+				wantSourceTags:   nil,
+				wantLogGroupTags: copyMap(logGroupTags),
+				wantFaasTags: func() map[string]string {
+					var m = make(map[string]string)
+					for k, v := range copyMap(functionTags) {
+						m[k] = v
+					}
+					for k, v := range copyMap(forwarderTags) {
+						m[k] = v
+					}
+					return m
+				}(),
+			}
 		},
-		{
-			desc: "got empty tags from resources",
-			config: &cfg.Config{
-				ForwardSourceTags:    true,
-				ForwardForwarderTags: true,
-				Region:               "us-west-2",
-			},
-			resourceClient: &mockResourceClient{
-				tags: map[string]map[string]string{},
-				err:  nil,
-			},
-			wantFaasTags: map[string]string{},
+		func() testCase {
+			return testCase{
+				desc: "Get tags when source is lambda and with forwarder tags and with prefix to prevent duplication",
+				config: &cfg.Config{
+					ForwardSourceTags:         true,
+					ForwardForwarderTags:      true,
+					ForwardLogGroupTags:       true,
+					Region:                    "us-west-2",
+					SourceEnvironmentPrefixes: "ed_forwarder=ed_fwd_",
+				},
+				arnsToGetTags:  []string{functionARN, logGroupARN, forwarderARN},
+				isSourceLambda: true,
+				resourceClient: &mockResourceClient{
+					tags: map[string]map[string]string{
+						functionARN:  copyMap(functionTags),
+						logGroupARN:  copyMap(logGroupTags),
+						forwarderARN: copyMap(forwarderTags),
+					},
+				},
+				wantSourceTags:   nil,
+				wantLogGroupTags: copyMap(logGroupTags),
+				wantFaasTags: func() map[string]string {
+					var m = make(map[string]string)
+					for k, v := range copyMap(functionTags) {
+						m[k] = v
+					}
+					for k, v := range copyMap(forwarderTags) {
+						utils.SetKeyWithPrefix(m, "ed_fwd_", k, v)
+					}
+					return m
+				}(),
+			}
+		},
+		func() testCase {
+			return testCase{
+				desc: "Get tags when source is ECS and with forwarder tags and with prefix to prevent duplication",
+				config: &cfg.Config{
+					ForwardSourceTags:         true,
+					ForwardForwarderTags:      true,
+					ForwardLogGroupTags:       true,
+					Region:                    "us-west-2",
+					SourceEnvironmentPrefixes: "ecs_task=task_prefix_,ecs_cluster=cluster_prefix_,ecs_service=service_prefix_",
+				},
+				arnsToGetTags: []string{logGroupARN, forwarderARN, ecsClusterARN, ecsTaskARN, ecsServiceARN},
+				resourceClient: &mockResourceClient{
+					tags: map[string]map[string]string{
+						logGroupARN:   copyMap(logGroupTags),
+						forwarderARN:  copyMap(forwarderTags),
+						ecsClusterARN: copyMap(ecsClusterTags),
+						ecsTaskARN:    copyMap(ecsTaskTags),
+						ecsServiceARN: copyMap(ecsServiceTags),
+					},
+				},
+				wantSourceTags: func() map[string]string {
+					var m = make(map[string]string)
+					for k, v := range copyMap(ecsClusterTags) {
+						utils.SetKeyWithPrefix(m, "cluster_prefix_", k, v)
+					}
+					for k, v := range copyMap(ecsTaskTags) {
+						utils.SetKeyWithPrefix(m, "task_prefix_", k, v)
+					}
+					for k, v := range copyMap(ecsServiceTags) {
+						utils.SetKeyWithPrefix(m, "service_prefix_", k, v)
+					}
+					return m
+				}(),
+				wantLogGroupTags: copyMap(logGroupTags),
+				wantFaasTags:     copyMap(forwarderTags),
+			}
+		},
+		func() testCase {
+			return testCase{
+				desc: "Get tags when source is ECS and with forwarder tags and without prefix",
+				config: &cfg.Config{
+					ForwardSourceTags:         true,
+					ForwardForwarderTags:      true,
+					ForwardLogGroupTags:       true,
+					Region:                    "us-west-2",
+					SourceEnvironmentPrefixes: "",
+				},
+				arnsToGetTags: []string{logGroupARN, forwarderARN, ecsClusterARN, ecsTaskARN, ecsServiceARN},
+				resourceClient: &mockResourceClient{
+					tags: map[string]map[string]string{
+						logGroupARN:   copyMap(logGroupTags),
+						forwarderARN:  copyMap(forwarderTags),
+						ecsClusterARN: copyMap(ecsClusterTags),
+						ecsTaskARN:    copyMap(ecsTaskTags),
+						ecsServiceARN: copyMap(ecsServiceTags),
+					},
+				},
+				wantSourceTags: func() map[string]string {
+					var m = make(map[string]string)
+					for k, v := range copyMap(ecsClusterTags) {
+						m[k] = v
+					}
+					for k, v := range copyMap(ecsTaskTags) {
+						m[k] = v
+					}
+					for k, v := range copyMap(ecsServiceTags) {
+						m[k] = v
+					}
+					return m
+				}(),
+				wantLogGroupTags: copyMap(logGroupTags),
+				wantFaasTags:     copyMap(forwarderTags),
+			}
 		},
 	}
 
 	for _, tc := range tests {
-		tc := tc
+		tc := tc()
 		t.Run(tc.desc, func(t *testing.T) {
 			// Clear global cache
-			defer delete(resourceARNToTagsCache, functionARN)
+			defer func() {
+				resourceARNToTagsCache = make(map[string]map[string]string)
+			}()
 
 			enricher := NewEnricher(tc.config, tc.resourceClient, lambda.NewNoOpClient())
-			_, faasTags, _ := enricher.getAllTags(context.TODO(), forwarderARN, logGroupARN, []string{functionARN}, true)
+			sourceTags, faasTags, logGroupTags := enricher.getAllTags(context.Background(), forwarderARN, logGroupARN, tc.arnsToGetTags, arnToSourceMap, tc.isSourceLambda)
 			if diff := cmp.Diff(tc.wantFaasTags, faasTags); diff != "" {
-				t.Errorf("Tags mismatch (-want +got):\n%s", diff)
+				t.Errorf("Faas tags mismatch (-want +got):\n%s", diff)
+			}
+
+			if diff := cmp.Diff(tc.wantSourceTags, sourceTags); diff != "" {
+				t.Errorf("Source tags mismatch (-want +got):\n%s", diff)
+			}
+
+			if diff := cmp.Diff(tc.wantLogGroupTags, logGroupTags); diff != "" {
+				t.Errorf("Lambda tags mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}

--- a/enrich/type.go
+++ b/enrich/type.go
@@ -1,0 +1,53 @@
+package enrich
+
+import (
+	"github.com/edgedelta/edgedelta-forwarder/lambda"
+	"github.com/edgedelta/edgedelta-forwarder/resource"
+	"github.com/edgedelta/edgedelta-forwarder/tag"
+)
+
+type Enricher struct {
+	resourceCl           resource.Client
+	lambdaCl             lambda.Client
+	region               string
+	sourcePrefixMap      map[tag.Source]string
+	forwardForwarderTags bool
+	forwardSourceTags    bool
+	forwardLogGroupTags  bool
+}
+
+type Common struct {
+	Cloud              *cloud     `json:"cloud"`
+	Faas               *faas      `json:"faas"`
+	AwsCommon          *awsCommon `json:"aws"`
+	HostArchitecture   string     `json:"host.arch,omitempty"`
+	ProcessRuntimeName string     `json:"process.runtime.name,omitempty"`
+}
+
+type faas struct {
+	Name       string            `json:"name"`
+	Version    string            `json:"version"`
+	RequestID  string            `json:"request_id,omitempty"`
+	MemorySize string            `json:"memory_size,omitempty"`
+	Tags       map[string]string `json:"tags,omitempty"`
+}
+
+type cloud struct {
+	ResourceID string `json:"resource_id"`
+	AccountID  string `json:"account_id"`
+	Region     string `json:"region"`
+}
+
+type awsLogs struct {
+	LogGroup               string            `json:"log.group.name"`
+	LogGroupARN            string            `json:"log.group.arn"`
+	LogGroupTags           map[string]string `json:"log.group.tags,omitempty"`
+	LogStream              string            `json:"log.stream.name"`
+	LogMessageType         string            `json:"log.message_type"`
+	LogSubscriptionFilters []string          `json:"log.subscription_filters"`
+}
+
+type awsCommon struct {
+	awsLogs
+	ServiceTags map[string]string `json:"service.tags,omitempty"`
+}

--- a/tag/type.go
+++ b/tag/type.go
@@ -1,0 +1,19 @@
+package tag
+
+type ServiceInfo struct {
+	Name Source
+	ARN  string
+}
+
+type Source string
+
+const (
+	SourceForwarder  Source = "ed_forwarder"
+	SourceLogGroup   Source = "log_group"
+	SourceSagemaker  Source = "sagemaker"
+	SourceECSTask    Source = "ecs_task"
+	SourceECSCluster Source = "ecs_cluster"
+	SourceECSService Source = "ecs_service"
+	SourceEC2        Source = "ec2"
+	SourceSNS        Source = "sns"
+)

--- a/template.yaml.tmpl
+++ b/template.yaml.tmpl
@@ -38,6 +38,10 @@ Parameters:
     Type: Number
     Description: RetryInterval is the initial interval to wait until next retry (in milliseconds). It is increased exponentially until our process is shut down
     Default: 100
+  EDSourceTagPrefixes:
+    Type: String
+    Description: Comma separated list of tag prefixes to prefix corresponding service tags. For example, `ed_forwarder=ed_fwd_,log_group=lg_` will prefix forwarder tags with `ed_fwd_` and log group tags with `lg_`.
+    Default: ''
 Outputs:
   EdgeDeltaForwarderArn:
     Description: EdgeDeltaForwarder Function ARN
@@ -64,6 +68,7 @@ Resources:
           ED_FORWARD_LOG_GROUP_TAGS: !Ref EDForwardLogGroupTags
           ED_PUSH_TIMEOUT_SEC: !Ref EDPushTimeoutSec
           ED_RETRY_INTERVAL_MS: !Ref EDRetryIntervalMs
+          ED_SOURCE_TAG_PREFIXES: !Ref EDSourceTagPrefixes
       Policies:
       - AWSLambdaBasicExecutionRole
       - Statement:

--- a/utils/helper.go
+++ b/utils/helper.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"bytes"
+	"strings"
 
 	"golang.org/x/sys/unix"
 )
@@ -24,4 +25,11 @@ func GetRuntimeArchitecture() string {
 	default:
 		return X86Architecture
 	}
+}
+
+func SetKeyWithPrefix(m map[string]string, prefix, k, v string) {
+	var sb strings.Builder
+	sb.WriteString(prefix)
+	sb.WriteString(k)
+	m[sb.String()] = v
 }


### PR DESCRIPTION
## Summary
This PR adds a setting to the configuration to add prefixing source tags to prevent duplication in the forwarder.

Fixes # [LS-598](https://edgedelta.atlassian.net/browse/LS-598)

## Testing
Extended enricher test and run with:
![image](https://github.com/edgedelta/edgedelta-forwarder/assets/111270176/30bc154c-b292-42c2-b1a4-fd2fbe8b0dd9)

Without prefix lambda run:
<img width="899" alt="image" src="https://github.com/edgedelta/edgedelta-forwarder/assets/111270176/37f3399c-4fe3-445b-96ec-8befd2d82007">


With prefix `ed_forwarder=ed_fwd_,lambda=lambda_prefix_`
![image](https://github.com/edgedelta/edgedelta-forwarder/assets/111270176/69172420-495d-4215-9931-20a95ff0a4e4)


With prefix `ecs_cluster=ecs_cluster_prefix_,ecs_service=ecs_service_prefix_,ecs_task=ecs_task_prefix_` ECS:
![image](https://github.com/edgedelta/edgedelta-forwarder/assets/111270176/110914f9-b506-4267-a029-2c3608bf478c)

WIthout prefix ECS:
![image](https://github.com/edgedelta/edgedelta-forwarder/assets/111270176/a7301b35-36d9-4bff-b131-cb037c004e88)
