### PR TITLE
set enable_cgo to false while building executable

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ AWS lambda function to forward logs from AWS to Edge Delta agent.
 - ED_FORWARD_FORWARDER_TAGS: If set to true, forwarder lambda's own tags are fetched. Requires "tag:GetResources" permission.
 - ED_FORWARD_LOG_GROUP_TAGS: If set to true, log group tags are fetched. Requires "tag:GetResources" permission.
 - ED_PUSH_TIMEOUT_SEC: Push timeout is the total duration of waiting for to send one batch of logs (in seconds). Default is 10.
-- ED_BATCH_SIZE: Batch size defines the maximum amount of logs the forwarder will send in one batch. The default and maximum batch size is 1MB, with a minimum of 50KB.
+- ED_BATCH_SIZE: Batch size is the max allowed size of data to send in one batch. The default (and also the maximum) batch size is 1MB, minimum is 50KB.
 - ED_RETRY_INTERVAL_MS: RetryInterval is the initial interval to wait until next retry (in milliseconds). It is increased exponentially until our process is shut down. Default is 100.
 - ED_SOURCE_TAG_PREFIXES: Comma separated list of tag prefixes to be added to the source tags. For example, if ED_SOURCE_TAG_PREFIXES has "ed_forwarder=ed_fwd_", then all the forwarder tags will be prefixed with "ed_fwd_". Default is empty. Refer to mapping below for the list of tags keys.
 
@@ -19,7 +19,7 @@ AWS lambda function to forward logs from AWS to Edge Delta agent.
 
 ### Step 1 - Build executable
 ```
-GOOS=linux GOARCH=amd64 go build -tags lambda.norpc -o bootstrap main.go
+GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -tags lambda.norpc -o bootstrap main.go
 ```
 Executable’s name must be “bootstrap”
 

--- a/deploy/build.sh
+++ b/deploy/build.sh
@@ -32,7 +32,7 @@ rm -rf "${project_root}/bin"
 mkdir -p "${project_root}/bin"
 
 cd "${project_root}"
-GOOS=linux GOARCH=$arch_type go build -tags lambda.norpc -o "$exe_path" main.go
+GOOS=linux GOARCH=$arch_type CGO_ENABLED=0 go build -tags lambda.norpc -o "$exe_path" main.go
 chmod +x "$exe_path"
 
 cd "${project_root}/bin"

--- a/template.yaml.tmpl
+++ b/template.yaml.tmpl
@@ -36,7 +36,7 @@ Parameters:
     Default: 10
   EDBatchSize:
     Type: Number
-    Description: BatchSize is the maximum number of log events to send in one batch
+    Description: Batch size is the max allowed size of data to send in one batch. The default (and also the maximum) batch size is 1MB, minimum is 50KB.
     Default: 1000000
   EDRetryIntervalMs:
     Type: Number


### PR DESCRIPTION
## Summary

This PR ensures we don't have any cgo dependent binaries. It also has some simple document updates.