### PR TITLE
invoke permissions depends on forwarder

### DIFF
--- a/template.yaml.tmpl
+++ b/template.yaml.tmpl
@@ -89,6 +89,7 @@ Resources:
 
   LambdaInvokePermission:
     Type: AWS::Lambda::Permission
+    DependsOn: EdgeDeltaForwarder
     Properties:
       FunctionName: !Ref EDLambdaFunctionName
       Action: lambda:InvokeFunction


### PR DESCRIPTION
## Summary
We need to wait until EdgeDeltaForwarder is created to create the related lambda invoke permission.
